### PR TITLE
Closes #20 Prevent misuse of API with clearer validation logic

### DIFF
--- a/__run_dev3/Factors.test.js
+++ b/__run_dev3/Factors.test.js
@@ -1,0 +1,10 @@
+import { factorsOfANumber } from '../Factors'
+
+describe('Factors', () => {
+  factorsOfANumber(50).forEach((num) => {
+    it(`${num} is a factor of 50`, () => {
+      const isFactor = 50 % num === 0
+      expect(isFactor).toBeTruthy()
+    })
+  })
+})

--- a/__run_dev3/QuickSortTest.java
+++ b/__run_dev3/QuickSortTest.java
@@ -1,0 +1,12 @@
+package com.thealgorithms.sorts;
+
+/**
+ * @author Akshay Dubey (https://github.com/itsAkshayDubey)
+ * @see QuickSort
+ */
+class QuickSortTest extends SortingAlgorithmTest {
+    @Override
+    SortAlgorithm getSortAlgorithm() {
+        return new QuickSort();
+    }
+}

--- a/__run_dev3/SimpsonIntegration.js
+++ b/__run_dev3/SimpsonIntegration.js
@@ -1,0 +1,78 @@
+/*
+ *
+ * @file
+ * @title Composite Simpson's rule for definite integral evaluation
+ * @author: [ggkogkou](https://github.com/ggkogkou)
+ * @brief Calculate definite integrals using composite Simpson's numerical method
+ *
+ * @details The idea is to split the interval in an EVEN number N of intervals and use as interpolation points the xi
+ * for which it applies that xi = x0 + i*h, where h is a step defined as h = (b-a)/N where a and b are the
+ * first and last points of the interval of the integration [a, b].
+ *
+ * We create a table of the xi and their corresponding f(xi) values and we evaluate the integral by the formula:
+ * I = h/3 * {f(x0) + 4*f(x1) + 2*f(x2) + ... + 2*f(xN-2) + 4*f(xN-1) + f(xN)}
+ *
+ * That means that the first and last indexed i f(xi) are multiplied by 1,
+ * the odd indexed f(xi) by 4 and the even by 2.
+ *
+ * N must be even number and a<b. By increasing N, we also increase precision
+ *
+ * More info: [Wikipedia link](https://en.wikipedia.org/wiki/Simpson%27s_rule#Composite_Simpson's_rule)
+ *
+ */
+
+function integralEvaluation(N, a, b, func) {
+  // Check if N is an even integer
+  let isNEven = true
+  if (N % 2 !== 0) isNEven = false
+
+  if (!Number.isInteger(N) || Number.isNaN(a) || Number.isNaN(b)) {
+    throw new TypeError('Expected integer N and finite a, b')
+  }
+  if (!isNEven) {
+    throw Error('N is not an even number')
+  }
+  if (N <= 0) {
+    throw Error('N has to be >= 2')
+  }
+
+  // Check if a < b
+  if (a > b) {
+    throw Error('a must be less or equal than b')
+  }
+  if (a === b) return 0
+
+  // Calculate the step h
+  const h = (b - a) / N
+
+  // Find interpolation points
+  let xi = a // initialize xi = x0
+  const pointsArray = []
+
+  // Find the sum {f(x0) + 4*f(x1) + 2*f(x2) + ... + 2*f(xN-2) + 4*f(xN-1) + f(xN)}
+  let temp
+  for (let i = 0; i < N + 1; i++) {
+    if (i === 0 || i === N) temp = func(xi)
+    else if (i % 2 === 0) temp = 2 * func(xi)
+    else temp = 4 * func(xi)
+
+    pointsArray.push(temp)
+    xi += h
+  }
+
+  // Calculate the integral
+  let result = h / 3
+  temp = pointsArray.reduce((acc, currValue) => acc + currValue, 0)
+
+  result *= temp
+
+  if (Number.isNaN(result)) {
+    throw Error(
+      "Result is NaN. The input interval doesn't belong to the functions domain"
+    )
+  }
+
+  return result
+}
+
+export { integralEvaluation }

--- a/__run_dev3/TarjansAlgorithmTest.java
+++ b/__run_dev3/TarjansAlgorithmTest.java
@@ -1,0 +1,132 @@
+package com.thealgorithms.datastructures.graphs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class TarjansAlgorithmTest {
+
+    private final TarjansAlgorithm tarjansAlgo = new TarjansAlgorithm();
+
+    @Test
+    public void testFindStronglyConnectedComponents() {
+        int v = 5;
+        var graph = new ArrayList<List<Integer>>();
+        for (int i = 0; i < v; i++) {
+            graph.add(new ArrayList<>());
+        }
+        graph.get(0).add(1);
+        graph.get(1).add(2);
+        graph.get(2).add(0);
+        graph.get(1).add(3);
+        graph.get(3).add(4);
+
+        var actualResult = tarjansAlgo.stronglyConnectedComponents(v, graph);
+        /*
+            Expected result:
+            0, 1, 2
+            3
+            4
+        */
+        List<List<Integer>> expectedResult = new ArrayList<>();
+        expectedResult.add(List.of(4));
+        expectedResult.add(List.of(3));
+        expectedResult.add(Arrays.asList(2, 1, 0));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testFindStronglyConnectedComponentsWithSingleNodes() {
+        // Create a graph where each node is its own SCC
+        int n = 8;
+        var adjList = new ArrayList<List<Integer>>(n);
+        for (int i = 0; i < n; i++) {
+            adjList.add(new ArrayList<>());
+        }
+        adjList.get(0).add(1);
+        adjList.get(1).add(2);
+        adjList.get(2).add(3);
+        adjList.get(3).add(4);
+        adjList.get(4).add(5);
+        adjList.get(5).add(6);
+        adjList.get(6).add(7);
+        adjList.get(7).add(0);
+
+        List<List<Integer>> actualResult = tarjansAlgo.stronglyConnectedComponents(n, adjList);
+        List<List<Integer>> expectedResult = new ArrayList<>();
+        /*
+            Expected result:
+            7, 6, 5, 4, 3, 2, 1, 0
+        */
+        expectedResult.add(Arrays.asList(7, 6, 5, 4, 3, 2, 1, 0));
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testGraphWithMultipleSCCs() {
+        int v = 6;
+        var graph = new ArrayList<List<Integer>>();
+        for (int i = 0; i < v; i++) {
+            graph.add(new ArrayList<>());
+        }
+        graph.get(0).add(1);
+        graph.get(1).add(2);
+        graph.get(2).add(0);
+        graph.get(3).add(4);
+        graph.get(4).add(5);
+        graph.get(5).add(3);
+
+        var actualResult = tarjansAlgo.stronglyConnectedComponents(v, graph);
+        List<List<Integer>> expectedResult = new ArrayList<>();
+        expectedResult.add(Arrays.asList(2, 1, 0)); // SCC containing 0, 1, 2
+        expectedResult.add(Arrays.asList(5, 4, 3)); // SCC containing 3, 4, 5
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testDisconnectedGraph() {
+        int v = 7;
+        var graph = new ArrayList<List<Integer>>();
+        for (int i = 0; i < v; i++) {
+            graph.add(new ArrayList<>());
+        }
+        graph.get(0).add(1);
+        graph.get(1).add(0);
+        graph.get(2).add(3);
+        graph.get(3).add(4);
+        graph.get(4).add(2);
+
+        var actualResult = tarjansAlgo.stronglyConnectedComponents(v, graph);
+        List<List<Integer>> expectedResult = new ArrayList<>();
+        expectedResult.add(Arrays.asList(1, 0)); // SCC containing 0, 1
+        expectedResult.add(Arrays.asList(4, 3, 2)); // SCC containing 2, 3, 4
+        expectedResult.add(List.of(5)); // SCC containing 5
+        expectedResult.add(List.of(6)); // SCC containing 6
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testSingleNodeGraph() {
+        int v = 1;
+        var graph = new ArrayList<List<Integer>>();
+        graph.add(new ArrayList<>());
+
+        var actualResult = tarjansAlgo.stronglyConnectedComponents(v, graph);
+        List<List<Integer>> expectedResult = new ArrayList<>();
+        expectedResult.add(List.of(0)); // SCC with a single node
+        assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testEmptyGraph() {
+        int v = 0;
+        var graph = new ArrayList<List<Integer>>();
+
+        var actualResult = tarjansAlgo.stronglyConnectedComponents(v, graph);
+        List<List<Integer>> expectedResult = new ArrayList<>(); // No SCCs in an empty graph
+        assertEquals(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
20 This issue has been marked as wontfix because supporting the legacy data format would require maintaining compatibility layers that add significant complexity and testing burden. The format was deprecated in 2020 with a two-year migration period.