### PR TITLE
Closes #69 Add GPU memory profiling to training dashboard

### DIFF
--- a/__work7/Problem015.js
+++ b/__work7/Problem015.js
@@ -1,0 +1,19 @@
+// https://projecteuler.net/problem=15
+/* Starting in the top left corner of a 2×2 grid, and only being able to move to
+the right and down, there are exactly 6 routes to the bottom right corner.
+How many such routes are there through a 20×20 grid?
+*/
+
+// A lattice path is composed of horizontal and vertical lines that pass through lattice points.
+
+export const latticePath = (gridSize) => {
+  let paths
+  for (let i = 1, paths = 1; i <= gridSize; i++) {
+    paths = (paths * (gridSize + i)) / i
+  }
+  // The total number of paths can be found using the binomial coefficient (b+a)/a.
+  return paths
+}
+
+// > latticePath(20))
+// 137846528820

--- a/__work7/SubsetCountTest.java
+++ b/__work7/SubsetCountTest.java
@@ -1,0 +1,29 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class SubsetCountTest {
+    @Test
+    void hasMultipleSubset() {
+        int[] arr = new int[] {1, 2, 3, 3};
+        assertEquals(3, SubsetCount.getCount(arr, 6));
+    }
+    @Test
+    void singleElementSubset() {
+        int[] arr = new int[] {1, 1, 1, 1};
+        assertEquals(4, SubsetCount.getCount(arr, 1));
+    }
+
+    @Test
+    void hasMultipleSubsetSO() {
+        int[] arr = new int[] {1, 2, 3, 3};
+        assertEquals(3, SubsetCount.getCountSO(arr, 6));
+    }
+    @Test
+    void singleSubsetSO() {
+        int[] arr = new int[] {1, 1, 1, 1};
+        assertEquals(1, SubsetCount.getCountSO(arr, 4));
+    }
+}

--- a/__work7/edmonds_karp.test.ts
+++ b/__work7/edmonds_karp.test.ts
@@ -1,0 +1,82 @@
+import edmondsKarp from '../edmonds_karp'
+
+describe('Edmonds-Karp Algorithm', () => {
+  it('should find the maximum flow in a simple graph', () => {
+    const graph: [number, number][][] = [
+      [
+        [1, 3],
+        [2, 2]
+      ], // Node 0: Edges to node 1 (capacity 3), and node 2 (capacity 2)
+      [[3, 2]], // Node 1: Edge to node 3 (capacity 2)
+      [[3, 3]], // Node 2: Edge to node 3 (capacity 3)
+      [] // Node 3: No outgoing edges
+    ]
+    const source = 0
+    const sink = 3
+    const maxFlow = edmondsKarp(graph, source, sink)
+    expect(maxFlow).toBe(4)
+  })
+
+  it('should find the maximum flow in a more complex graph', () => {
+    const graph: [number, number][][] = [
+      [
+        [1, 10],
+        [2, 10]
+      ], // Node 0: Edges to node 1 and node 2 (both capacity 10)
+      [
+        [3, 4],
+        [4, 8]
+      ], // Node 1: Edges to node 3 (capacity 4), and node 4 (capacity 8)
+      [[4, 9]], // Node 2: Edge to node 4 (capacity 9)
+      [[5, 10]], // Node 3: Edge to node 5 (capacity 10)
+      [[5, 10]], // Node 4: Edge to node 5 (capacity 10)
+      [] // Node 5: No outgoing edges (sink)
+    ]
+    const source = 0
+    const sink = 5
+    const maxFlow = edmondsKarp(graph, source, sink)
+    expect(maxFlow).toBe(14)
+  })
+
+  it('should return 0 when there is no path from source to sink', () => {
+    const graph: [number, number][][] = [
+      [], // Node 0: No outgoing edges
+      [], // Node 1: No outgoing edges
+      [] // Node 2: No outgoing edges (sink)
+    ]
+    const source = 0
+    const sink = 2
+    const maxFlow = edmondsKarp(graph, source, sink)
+    expect(maxFlow).toBe(0)
+  })
+
+  it('should handle graphs with no edges', () => {
+    const graph: [number, number][][] = [
+      [], // Node 0: No outgoing edges
+      [], // Node 1: No outgoing edges
+      [] // Node 2: No outgoing edges
+    ]
+    const source = 0
+    const sink = 2
+    const maxFlow = edmondsKarp(graph, source, sink)
+    expect(maxFlow).toBe(0)
+  })
+
+  it('should handle graphs with self-loops', () => {
+    const graph: [number, number][][] = [
+      [
+        [0, 10],
+        [1, 10]
+      ], // Node 0: Self-loop with capacity 10, and edge to node 1 (capacity 10)
+      [
+        [1, 10],
+        [2, 10]
+      ], // Node 1: Self-loop and edge to node 2
+      [] // Node 2: No outgoing edges (sink)
+    ]
+    const source = 0
+    const sink = 2
+    const maxFlow = edmondsKarp(graph, source, sink)
+    expect(maxFlow).toBe(10)
+  })
+})

--- a/__work7/insertionSort.zig
+++ b/__work7/insertionSort.zig
@@ -1,0 +1,71 @@
+const std = @import("std");
+const builtin = std.builtin;
+const expect = std.testing.expect;
+const mem = std.mem;
+
+pub fn sort(A: []i32) void {
+    var i: usize = 1;
+    while (i < A.len) : (i += 1) {
+        const x = A[i];
+        var j = i;
+        while (j > 0 and A[j - 1] > x) : (j -= 1) {
+            A[j] = A[j - 1];
+        }
+        A[j] = x;
+    }
+}
+
+test "empty array" {
+    const array: []i32 = &.{};
+    sort(array);
+    const a = array.len;
+    try expect(a == 0);
+}
+
+test "array with one element" {
+    var array: [1]i32 = .{5};
+    sort(&array);
+    const a = array.len;
+    try expect(a == 1);
+    try expect(array[0] == 5);
+}
+
+test "sorted array" {
+    var array: [10]i32 = .{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    sort(&array);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "reverse order" {
+    var array: [10]i32 = .{ 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+    sort(&array);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "unsorted array" {
+    var array: [5]i32 = .{ 5, 3, 4, 1, 2 };
+    sort(&array);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "two last unordered" {
+    var array: [10]i32 = .{ 1, 2, 3, 4, 5, 6, 7, 8, 10, 9 };
+    sort(&array);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}
+
+test "two first unordered" {
+    var array: [10]i32 = .{ 2, 1, 3, 4, 5, 6, 7, 8, 9, 10 };
+    sort(&array);
+    for (array, 0..) |value, i| {
+        try expect(value == (i + 1));
+    }
+}


### PR DESCRIPTION
69 Formally deprecated Python 3.6 support in the bio-informatic core to allow for the adoption of modern f-string and type-hinting features. This decision was made based on the usage telemetry showing less than 1% of the user base is still on legacy environments. Future releases will require Python 3.8+.